### PR TITLE
Avoid warnings emession on re-importing Font::FreeType

### DIFF
--- a/FreeType.xs
+++ b/FreeType.xs
@@ -327,9 +327,11 @@ qefft2_import (const char *target_pkg)
         stash = gv_stashpv(target_pkg, 0);
         if (!stash)
             croak("the package I'm importing into doesn't seem to exist");
-        for (i = 0; i < sizeof(qefft2_uv_const) / sizeof(QefFT2_Uv_Const); ++i)
-            newCONSTSUB(stash, qefft2_uv_const[i].name,
-                        newSVuv(qefft2_uv_const[i].value));
+        for (i = 0; i < sizeof(qefft2_uv_const) / sizeof(QefFT2_Uv_Const); ++i) {
+            const char* name = qefft2_uv_const[i].name;
+            if ( !hv_exists(stash, name, strlen(name)) )
+                 newCONSTSUB(stash, name,  newSVuv(qefft2_uv_const[i].value));
+        }
 
 
 Font_FreeType

--- a/t/05library.t
+++ b/t/05library.t
@@ -3,7 +3,8 @@
 
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 5;
+use Test::Warnings;
 use Font::FreeType;
 
 # Make an object.
@@ -16,5 +17,8 @@ my $version = $ft->version;
 ok($version =~ /^\d+\.\d+\.\d+\z/, 'version number should be formated right');
 is(join('.', $ft->version), $version,
    'version() in list context should return same nums as in scalar context');
+
+eval 'use Font::FreeType'; # should not emit redefinition warnings
+ok !$@, 'successfully re-imported Font::FreeType';
 
 # vim:ft=perl ts=4 sw=4 expandtab:


### PR DESCRIPTION
Without patch there are irritating warnings, without possibility to track warnings source and fix it.

```
$ perl -I lib -I blib/arch -e 'use Font::FreeType; use Font::FreeType;'
Constant subroutine FT_LOAD_DEFAULT redefined at -e line 4294967295.
Constant subroutine FT_LOAD_NO_SCALE redefined at -e line 4294967295.
Constant subroutine FT_LOAD_NO_HINTING redefined at -e line 4294967295.
Constant subroutine FT_LOAD_NO_BITMAP redefined at -e line 4294967295.
Constant subroutine FT_LOAD_VERTICAL_LAYOUT redefined at -e line 4294967295.
Constant subroutine FT_LOAD_FORCE_AUTOHINT redefined at -e line 4294967295.
Constant subroutine FT_LOAD_CROP_BITMAP redefined at -e line 4294967295.
Constant subroutine FT_LOAD_PEDANTIC redefined at -e line 4294967295.
Constant subroutine FT_LOAD_IGNORE_GLOBAL_ADVANCE_WIDTH redefined at -e line 4294967295.
Constant subroutine FT_LOAD_IGNORE_TRANSFORM redefined at -e line 4294967295.
Constant subroutine FT_LOAD_LINEAR_DESIGN redefined at -e line 4294967295.
Constant subroutine FT_LOAD_NO_AUTOHINT redefined at -e line 4294967295.
Constant subroutine FT_RENDER_MODE_NORMAL redefined at -e line 4294967295.
Constant subroutine FT_RENDER_MODE_LIGHT redefined at -e line 4294967295.
Constant subroutine FT_RENDER_MODE_MONO redefined at -e line 4294967295.
Constant subroutine FT_RENDER_MODE_LCD redefined at -e line 4294967295.
Constant subroutine FT_RENDER_MODE_LCD_V redefined at -e line 4294967295.
Constant subroutine FT_KERNING_DEFAULT redefined at -e line 4294967295.
Constant subroutine FT_KERNING_UNFITTED redefined at -e line 4294967295.
Constant subroutine FT_KERNING_UNSCALED redefined at -e line 4294967295.
```

PS. I'm participating in 24pullrequests.com competition. Do you? :)
