### PR TITLE
Another debian patches.

### DIFF
--- a/FreeType.xs
+++ b/FreeType.xs
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 #include <ft2build.h>
-#include <ftsnames.h>
+#include FT_SFNT_NAMES_H
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 #include FT_OUTLINE_H


### PR DESCRIPTION
Hello Zaki,

The typo fix is trivial and correct, while the 2nd patch seems to be strange:

```
-        row_buf = New(0, row_buf, bitmap->width, unsigned char);
+        New(0, row_buf, bitmap->width, unsigned char);
```

Removing _row_buf_ while it is used a few lines below? I think it will crash.

PS. The build isn't fixed yet. I have asked one person to test and it failed to locate _ftsnames.h_, recently introduced.
