### PR TITLE
Allow looking up glyphs by name.

### DIFF
--- a/lib/Font/FreeType/Face.pm
+++ b/lib/Font/FreeType/Face.pm
@@ -128,6 +128,25 @@ Returns I<undef> if the glyph is not available in the font and
 I<fallback> isn't defined; otherwise, i.e. if I<fallback = true>
 returns fonts I<missing glyph>.
 
+=item get_name_index(I<name>)
+
+Looks up a glyph by name and returns the index for that glyph in the
+font. Returns 0 if the name is not found.
+
+=item glyph_from_index(I<index>)
+
+Returns a L<Font::FreeType::Glyph|Font::FreeType::Glyph> object for the
+glyph at the given index.
+
+=item glyph_from_name(I<name>, I<fallback = 0>)
+
+Looks up a glyph by name and returns a
+L<Font::FreeType::Glyph|Font::FreeType::Glyph> object.
+
+Returns I<undef> if the glyph is not available in the font and
+I<fallback> isn't defined; otherwise, i.e. if I<fallback = true>
+returns fonts I<missing glyph>.
+
 =item has_glyph_names()
 
 True if individual glyphs have names.  If so, the names can be

--- a/t/10metrics_verasans.t
+++ b/t/10metrics_verasans.t
@@ -9,13 +9,16 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 78 + 5 * 2 + 256 * 2 + 5;
+use Test::More;
 use File::Spec::Functions;
 use Font::FreeType;
+
+my $Tests;
 
 my $data_dir = catdir(qw( t data ));
 
 # Load the Vera Sans face.
+BEGIN { $Tests = 2 }
 my $ft = Font::FreeType->new;
 my $vera = $ft->face(catfile($data_dir, 'Vera.ttf'));
 ok($vera, 'FreeType->face() should return an object');
@@ -23,6 +26,7 @@ is(ref $vera, 'Font::FreeType::Face',
     'FreeType->face() should return blessed ref');
 
 # Test general properties of the face.
+BEGIN { $Tests += 5 }
 is($vera->number_of_faces, 1, '$face->number_of_faces() is right');
 is($vera->current_face_index, 0, '$face->current_face_index() is right');
 
@@ -47,6 +51,7 @@ my %expected_flags = (
     is_sfnt => 1,
 );
 
+BEGIN { $Tests += 10 }
 foreach my $method (sort keys %expected_flags) {
     my $expected = $expected_flags{$method};
     my $got = $vera->$method();
@@ -59,6 +64,7 @@ foreach my $method (sort keys %expected_flags) {
 }
 
 # Some other general properties.
+BEGIN { $Tests += 8 }
 is($vera->number_of_glyphs, 268, '$face->number_of_glyphs() is right');
 is($vera->units_per_em, 2048, '$face->units_per_em() is right');
 my $underline_position = $vera->underline_position;
@@ -73,6 +79,8 @@ is($vera->height, 2384, 'height');
 # Test getting the set of fixed sizes available.
 my @fixed_sizes = $vera->fixed_sizes;
 is(scalar @fixed_sizes, 0, 'Vera has no fixed sizes');
+
+BEGIN { $Tests += 3 }
 
 subtest "charmaps" => sub {
     subtest "default charmap" => sub {
@@ -122,6 +130,8 @@ subtest "bounding box" => sub {
 my $glyph_list_filename = catfile($data_dir, 'vera_glyphs.txt');
 open my $glyph_list, '<', $glyph_list_filename
   or die "error opening file for list of glyphs: $!";
+
+BEGIN { $Tests += 256*2 + 1 }
 $vera->foreach_char(sub {
     die "shouldn't be any argumetns passed in" unless @_ == 0;
     my $line = <$glyph_list>;
@@ -136,42 +146,63 @@ $vera->foreach_char(sub {
 });
 is(scalar <$glyph_list>, undef, "we aren't missing any glyphs");
 
-
 # Test metrics on some particlar glyphs.
-my %glyph_metrics = (
-    'A' => { name => 'A', advance => 1401,
-             LBearing => 16, RBearing => 17 },
-    '_' => { name => 'underscore', advance => 1024,
-             LBearing => -20, RBearing => -20 },
-    '`' => { name => 'grave', advance => 1024,
-             LBearing => 170, RBearing => 375 },
-    'g' => { name => 'g', advance => 1300,
-             LBearing => 113, RBearing => 186 },
-    '|' => { name => 'bar', advance => 690,
-             LBearing => 260, RBearing => 260 },
+my @glyph_metrics = (
+    { name => 'A', char => 'A', ccode => 65, index => 36,
+        advance => 1401, LBearing => 16, RBearing => 17 },
+    { name => 'underscore', char => '_', ccode => 95, index => 66,
+        advance => 1024, LBearing => -20, RBearing => -20 },
+    { name => 'grave', char => '`', ccode => 96, index => 67,
+        advance => 1024, LBearing => 170, RBearing => 375 },
+    { name => 'g', char => 'g', ccode => 103, index => 74,
+        advance => 1300, LBearing => 113, RBearing => 186 },
+    { name => 'bar', char => '|', ccode => 124, index => 95,
+        advance => 690, LBearing => 260, RBearing => 260 },
 );
 
 # Set the size to match the em size, so that the values are in font units.
 $vera->set_char_size(2048, 2048, 72, 72);
 
-# 5*2 tests.
-foreach my $get_by_code (0 .. 1) {
-    foreach my $char (sort keys %glyph_metrics) {
-        my $glyph = $get_by_code ? $vera->glyph_from_char_code(ord $char)
-                                 : $vera->glyph_from_char($char);
+BEGIN { $Tests += 5*4*7 }
+foreach my $get_by (qw/char code index name/) {
+    foreach (@glyph_metrics) {
+        my $glyph;
+        if ($get_by eq "char") {
+            $glyph = $vera->glyph_from_char($_->{char});
+        }
+        elsif ($get_by eq "code") {
+            $glyph = $vera->glyph_from_char_code($_->{ccode});
+        }
+        elsif ($get_by eq "index") {
+            $glyph = $vera->glyph_from_index($_->{index});
+        }
+        elsif ($get_by eq "name") {
+            $glyph = $vera->glyph_from_name($_->{name});
+        }
+        my $char = $_->{char};
         die "no glyph for character '$char'" unless $glyph;
-        local $_ = $glyph_metrics{$char};
         is($glyph->name, $_->{name},
-           "name of glyph '$char'");
+           "name of glyph '$char', by $get_by");
+        is($glyph->index, $_->{index},
+            "index of glyph '$char', by $get_by");
+        is($glyph->char_code, $_->{ccode},
+            "char code of glyph '$char', by $get_by");
         is($glyph->horizontal_advance, $_->{advance},
-           "advance width of glyph '$char'");
+           "advance width of glyph '$char', by $get_by");
         is($glyph->left_bearing, $_->{LBearing},
-           "left bearing of glyph '$char'");
+           "left bearing of glyph '$char', by $get_by");
         is($glyph->right_bearing, $_->{RBearing},
-           "right bearing of glyph '$char'");
+           "right bearing of glyph '$char', by $get_by");
         is($glyph->width, $_->{advance} - $_->{LBearing} - $_->{RBearing},
-           "width of glyph '$char'");
+           "width of glyph '$char', by $get_by");
     }
+}
+
+BEGIN { $Tests += 5 }
+for (@glyph_metrics) {
+    my $ix = $vera->get_name_index($_->{name});
+    is($ix, $_->{index},
+        "get_name_index for glyph '$$_{char}'");
 }
 
 # Test kerning.
@@ -182,6 +213,7 @@ my %kerning = (
     'T.' => -243,
 );
 
+BEGIN { $Tests += 4*2 }
 foreach my $pair (sort keys %kerning) {
     my ($kern_x, $kern_y) = $vera->kerning(
         map { $vera->glyph_from_char($_)->index } split //, $pair);
@@ -190,6 +222,7 @@ foreach my $pair (sort keys %kerning) {
 }
 
 # Get just the horizontal kerning more conveniently.
+BEGIN { $Tests += 6 }
 my $kern_x = $vera->kerning(
     map { $vera->glyph_from_char($_)->index } 'A', 'V');
 is($kern_x, -131, "horizontal kerning of 'AV' in scalar context");
@@ -203,5 +236,7 @@ is $missing_glyph->horizontal_advance, 1229, "missing glyph has horizontal advan
 
 is $vera->glyph_from_char_code(ord '˗', 0), undef, "no fallback glyph";
 isnt $vera->glyph_from_char_code(ord '˗', 1), undef, "missing glyph is defined";
+
+BEGIN { plan tests => $Tests }
 
 # vim:ft=perl ts=4 sw=4 expandtab:


### PR DESCRIPTION
This may mean creating a Glyph object without a valid char_code member.
It isn't possible to use -1 for this since char_code is unsigned; there
isn't in fact any value that can be safely used, since a char_code might
be any value from 0-0xFFFFFFFF. Add a new member to the Glyph structure
to use instead.