### PR TITLE
Adding an explicit glyph->load method, and documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.12 2018-08-14 htl10@users.sourceforge.net
+ - Added the face->load_flags getter and setter methods
+ - Fixed bugs loading glyph index 0 by name (".notdef") or by index.
+
 0.12 2018-08-11 htl10@users.sourceforge.net
  - Added an explicit glyph->load method
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.10_1 2018-08-11 htl10@users.sourceforge.net
+ - Added an explicit glyph->load method
+
 0.10_1 2018-08-07 htl10@users.sourceforge.net
  - Added FT_LOAD_COMPUTE_METRICS load flag
  - Added face->foreach_glyph method for iterating over all glyphs

--- a/FreeType.xs
+++ b/FreeType.xs
@@ -1093,6 +1093,15 @@ qefft2_glyph_vertical_advance (Font_FreeType_Glyph glyph)
         RETVAL
 
 
+void
+qefft2_glyph_load (Font_FreeType_Glyph glyph)
+    PREINIT:
+        FT_Face face;
+    CODE:
+        face = (FT_Face) SvIV(glyph->face_sv);
+        ensure_glyph_loaded(face, glyph);
+
+
 bool
 qefft2_glyph_has_outline (Font_FreeType_Glyph glyph)
     PREINIT:

--- a/FreeType.xs
+++ b/FreeType.xs
@@ -444,6 +444,22 @@ qefft2_face (Font_FreeType library, const char *filename, int faceidx, FT_Int32 
 MODULE = Font::FreeType   PACKAGE = Font::FreeType::Face   PREFIX = qefft2_face_
 
 
+FT_Int32
+qefft2_face_load_flags (Font_FreeType_Face face, FT_Int32 val = NO_INIT )
+    PREINIT:
+        QefFT2_Face_Extra *extra;
+    CODE:
+        extra = face->generic.data;
+        if( items > 1 )
+        {
+            extra->slot_valid = false;
+            extra->glyph_load_flags = val;
+        }
+        RETVAL = extra->glyph_load_flags;
+    OUTPUT:
+        RETVAL
+
+
 void
 qefft2_face_DESTROY (Font_FreeType_Face face)
     PREINIT:

--- a/FreeType.xs
+++ b/FreeType.xs
@@ -871,7 +871,7 @@ qefft2_face_glyph_from_name (Font_FreeType_Face face, SV *sv, int fallback = 0)
     CODE:
         name = SvPV_nolen(sv);
         ix = FT_Get_Name_Index(face, name);
-        if (ix || fallback)
+        if (ix || fallback || !strcmp(name, ".notdef"))
             RETVAL = make_glyph(SvRV(ST(0)), 0, 0, ix);
         else
             RETVAL = &PL_sv_undef;

--- a/lib/Font/FreeType/Face.pm
+++ b/lib/Font/FreeType/Face.pm
@@ -255,6 +255,14 @@ Leave the measurements in font units, without scaling, and without hinting.
 
 =back
 
+=item load_flags()
+
+Retrieve the I<load_flags> option used.
+
+=item load_flags(I<load_flags>)
+
+Setting the I<load_flags> option. Returns the newly set value.
+
 =item number_of_faces()
 
 The number of faces contained in the file from which this one

--- a/lib/Font/FreeType/Glyph.pm
+++ b/lib/Font/FreeType/Glyph.pm
@@ -290,6 +290,15 @@ The left side bearing, which is the distance from the origin to
 the left of the glyph image.  Usually positive for horizontal layouts
 and negative for vertical ones.
 
+=item load()
+
+Tell FreeType to load the glyph. There are very few reasons to use
+this as it is called implicitly if needed, by most of the other methods.
+
+A few of these reasons include: timing or profiling tests of
+FreeType, debugging FreeType via side effects of glyph loading
+(by setting FT2_DEBUG).
+
 =item name()
 
 The name of the glyph, if the font format supports glyph names,

--- a/t/10metrics_verasans.t
+++ b/t/10metrics_verasans.t
@@ -219,6 +219,49 @@ foreach my $get_by (qw/char code index name/) {
     }
 }
 
+# The 12 glyphs which don't have char code.
+my @glyph_metrics_nochar = (
+    { name => '.notdef', index => 0, advance => 1229, LBearing => 102, RBearing => 103 },
+    { name => '.null', index => 1, advance => 0, LBearing => 0, RBearing => 0 },
+    { name => 'nonmarkingreturn', index => 2, advance => 651, LBearing => 0, RBearing => 651 },
+    { name => 'c6459', index => 259, advance => 1024, LBearing => 215, RBearing => 215 },
+    { name => 'c6460', index => 260, advance => 1024, LBearing => 371, RBearing => 272 },
+    { name => 'c6461', index => 261, advance => 1024, LBearing => 182, RBearing => 182 },
+    { name => 'c6462', index => 262, advance => 1024, LBearing => 268, RBearing => 373 },
+    { name => 'c6463', index => 263, advance => 1024, LBearing => 207, RBearing => 207 },
+    { name => 'c6466', index => 264, advance => 1024, LBearing => 207, RBearing => 207 },
+    { name => 'c6467', index => 265, advance => 821, LBearing => 63, RBearing => 65 },
+    { name => 'c6468', index => 266, advance => 1024, LBearing => 199, RBearing => 199 },
+    { name => 'c6469', index => 267, advance => 1024, LBearing => 410, RBearing => 410 },
+);
+
+BEGIN { $Tests += 12*2*7 }
+foreach my $get_by (qw/index name/) {
+    foreach (@glyph_metrics_nochar) {
+        my $glyph;
+        if ($get_by eq "index") {
+            $glyph = $vera->glyph_from_index($_->{index});
+        }
+        elsif ($get_by eq "name") {
+            $glyph = $vera->glyph_from_name($_->{name});
+        }
+        is($glyph->name, $_->{name},
+           "name of glyph '$_->{index}', by $get_by");
+        is($glyph->index, $_->{index},
+            "index of glyph '$_->{index}', by $get_by");
+        is($glyph->char_code, undef,
+            "char code of glyph '$_->{index}', by $get_by");
+        is($glyph->horizontal_advance, $_->{advance},
+           "advance width of glyph '$_->{index}', by $get_by");
+        is($glyph->left_bearing, $_->{LBearing},
+           "left bearing of glyph '$_->{index}', by $get_by");
+        is($glyph->right_bearing, $_->{RBearing},
+           "right bearing of glyph '$_->{index}', by $get_by");
+        is($glyph->width, $_->{advance} - $_->{LBearing} - $_->{RBearing},
+           "width of glyph '$_->{index}', by $get_by");
+    }
+}
+
 BEGIN { $Tests += 5 }
 for (@glyph_metrics) {
     my $ix = $vera->get_name_index($_->{name});

--- a/t/10metrics_verasans.t
+++ b/t/10metrics_verasans.t
@@ -261,6 +261,15 @@ foreach my $get_by (qw/index name/) {
            "width of glyph '$_->{index}', by $get_by");
     }
 }
+BEGIN { $Tests += 3 }
+is($vera->load_flags, FT_LOAD_DEFAULT, "FT_LOAD_DEFAULT");
+is($vera->load_flags(FT_LOAD_COMPUTE_METRICS), FT_LOAD_COMPUTE_METRICS, "FT_LOAD_COMPUTE_METRICS");
+is($vera->load_flags, FT_LOAD_COMPUTE_METRICS, "FT_LOAD_COMPUTE_METRICS");
+
+BEGIN { $Tests += 268 }
+$vera->foreach_glyph(sub {
+ok defined eval {$_->load(); $_->name; }
+;});
 
 BEGIN { $Tests += 5 }
 for (@glyph_metrics) {


### PR DESCRIPTION
There are very few reasons to use this as it is called implicitly if
needed, by most of the other methods.

A few of these reasons include: timing or profiling tests of
FreeType, debugging FreeType via side effects of glyph loading
(by setting FT2_DEBUG).