### PR TITLE
fix typo

### DIFF
--- a/lib/Font/FreeType/CharMap.pm
+++ b/lib/Font/FreeType/CharMap.pm
@@ -31,7 +31,7 @@ per font.
 =head1 CONSTANTS
 
 The following encoding constants are exported by default by L<Font::FreeType>.
-See L<freetype documenation|http://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#FT_Encoding>
+See L<freetype documentation|http://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#FT_Encoding>
 
 =head2 FT_ENCODING_NONE
 


### PR DESCRIPTION
found by Debian's lintian spellchecker